### PR TITLE
hk: bump rexml (security), prep 0.14.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,43 @@
 PATH
   remote: .
   specs:
-    sortable-by (0.14.2)
+    sortable-by (0.14.3)
       activerecord
       activesupport
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (7.0.7.2)
-      activesupport (= 7.0.7.2)
-    activerecord (7.0.7.2)
-      activemodel (= 7.0.7.2)
-      activesupport (= 7.0.7.2)
-    activesupport (7.0.7.2)
+    activemodel (7.1.3.3)
+      activesupport (= 7.1.3.3)
+    activerecord (7.1.3.3)
+      activemodel (= 7.1.3.3)
+      activesupport (= 7.1.3.3)
+      timeout (>= 0.4.0)
+    activesupport (7.1.3.3)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     ast (2.4.2)
     base64 (0.1.1)
-    concurrent-ruby (1.2.2)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
-    i18n (1.14.1)
+    drb (2.2.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     mini_portile2 (2.8.4)
-    minitest (5.19.0)
+    minitest (5.23.1)
+    mutex_m (0.2.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -36,7 +46,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -85,6 +96,8 @@ GEM
     ruby-progressbar (1.13.0)
     sqlite3 (1.6.4)
       mini_portile2 (~> 2.8.0)
+    strscan (3.1.0)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)

--- a/Gemfile.rails6.lock
+++ b/Gemfile.rails6.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sortable-by (0.14.2)
+    sortable-by (0.14.3)
       activerecord
       activesupport
 
@@ -36,7 +36,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -84,6 +85,7 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     sqlite3 (1.6.4-x86_64-linux)
+    strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)

--- a/sortable-by.gemspec
+++ b/sortable-by.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'sortable-by'
-  s.version     = '0.14.2'
+  s.version     = '0.14.3'
   s.authors     = ['Dimitrij Denissenko']
   s.email       = ['dimitrij@blacksquaremedia.com']
   s.summary     = 'Generate white-listed sort scopes from URL parameter values'


### PR DESCRIPTION
Replaces https://github.com/bsm/sortable-by/pull/20

TODO

- merge this
- close https://github.com/bsm/sortable-by/pull/20
- tag a version
- publish to rubygems